### PR TITLE
Fix epmd service existence check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ install: user $(LOGDIR)
 	chmod 777 $(prefix)/mtp_proxy/log/
 	install -D config/mtproto-proxy.service $(SERVICE)
 # If there is no "epmd" service, install one
-	if [ -z "`systemctl show -p FragmentPath --value epmd`" ]; then \
+	if [ -z "`systemctl show epmd --property=FragmentPath`" ]; then \
 	    install -D config/epmd.service $(EPMD_SERVICE); \
 	fi
 	systemctl daemon-reload


### PR DESCRIPTION
systemctl doesnt have --value option. I was getting this error `systemctl: unrecognized option '--value'` on CentOS 7.6 after `make install`
https://manpages.debian.org/jessie/systemd/systemctl.1.en.html