### PR TITLE
Make core API HTTP timeout configurable

### DIFF
--- a/src/mtp_config.erl
+++ b/src/mtp_config.erl
@@ -270,8 +270,9 @@ http_get(Url) ->
     UserAgent = ("MTProtoProxy/" ++ Vsn ++ " OTP-" ++ OtpVersion ++
                      " (+https://github.com/seriyps/mtproto_proxy)"),
     Headers = [{"User-Agent", UserAgent}],
+    Timeout = application:get_env(mtproto_proxy, core_api_http_timeout_ms, 3000),
     {ok, {{_, 200, _}, _, Body}} =
-        httpc:request(get, {Url, Headers}, [{timeout, 3000}], ?OPTS),
+        httpc:request(get, {Url, Headers}, [{timeout, Timeout}], ?OPTS),
     {ok, Body}.
 
 random_choice(L) ->

--- a/src/mtproto_proxy.app.src
+++ b/src/mtproto_proxy.app.src
@@ -119,7 +119,7 @@
            %% Remove items used for the last time more than `max_age_minutes`
            %% minutes ago.
            %% Less than 10 minutes doesn't make much sense
-           max_age_minutes => 360}}
+           max_age_minutes => 360}},
 
         %% Should be module with function `notify/4' exported.
         %% See mtp_metric:notify/4 for details
@@ -138,6 +138,8 @@
         %% Mostly used to testing
         %% {proxy_secret_url, "https://core.telegram.org/getProxySecret"},
         %% {proxy_config_url, "https://core.telegram.org/getProxyConfig"},
+        %% HTTP timeout (ms) for fetching proxy config/secret
+        {core_api_http_timeout_ms, 3000}
 
         %% Upstream self-healthchecks tuning
         %% {upstream_healthchecks,


### PR DESCRIPTION
### Make core API HTTP timeout configurable

### Explanation / What it affects
`mtp_config` fetches proxy config and secret from core.telegram.org during startup. The HTTP request timeout was hard‑coded at 3s, so slower networks could cause startup crashes. This change introduces a config key so we can set an appropriate timeout in sys.config (default remains 3000ms).

### Before
Startup could crash with: 
`no match of right hand value {error,{failed_connect,[{to_address,{"core.telegram.org",443}},{inet,[inet],timeout}]}} in mtp_config:http_get/1 line 273`

### After
Timeout is configurable via `core_api_http_timeout_ms` (e.g., 120000 for 2 minutes), preventing startup failures on high‑latency links.