### PR TITLE
Change proxy link from https to tg deeplink

### DIFF
--- a/src/mtproto_proxy_app.erl
+++ b/src/mtproto_proxy_app.erl
@@ -236,7 +236,7 @@ node_role() ->
 build_urls(Host, Port, Secret, Protocols) ->
     MkUrl = fun(ProtoSecret) ->
                     io_lib:format(
-                      "https://t.me/proxy?server=~s&port=~w&secret=~s",
+                      "tg://proxy?server=~s&port=~w&secret=~s",
                       [Host, Port, ProtoSecret])
             end,
     UrlTypes = lists:usort(


### PR DESCRIPTION
Hi,
since `t.me` domain is blocked in Russia, I suggest using `tg://` deep links for sharing rather than `https://t.me/`.
It's more comfortable for Telegram users.